### PR TITLE
rename $.is and $.test

### DIFF
--- a/src/ender.js
+++ b/src/ender.js
@@ -1,4 +1,9 @@
 (function ($) {
-  var c = require('categorizr')
-  $.ender(c)
+  var c = require('categorizr'), o = {}, k
+  for (k in c) {
+    if (Object.hasOwnProperty.call(c, k)) {
+      o[k == 'test' ? 'testUserAgent' : k == 'is' ? 'isDeviceType' : k] = c[k]
+    }
+  }
+  $.ender(o)
 }(ender));


### PR DESCRIPTION
Consider this a gentle suggestion: `$.is` and `$.test` are pretty vanilla names and are there's a likelihood of causing clashes with other Ender packages (for example [valentine](https://github.com/ded/valentine/blob/master/src/valentine.js#L500)).

The main reason I'd like this changed though is a bit selfish because it's causing issues with Traversty's feature detection mechanism that looks for a selector engine at `$.is()` before going on to look for one at `$().is()`, see [here](https://github.com/rvagg/traversty/blob/master/src/traversty.js#L177). So even if you don't have a module conflicting with `$.is()` Traversty will try it out as a selector engine and fail.

Cheers!
